### PR TITLE
Only require files if in chassis environment

### DIFF
--- a/load.php
+++ b/load.php
@@ -1,4 +1,7 @@
 <?php
 
-require_once '/vagrant/local-config-db.php';
-require_once '/vagrant/local-config-extensions.php';
+if ( file_exists( '/vagrant/local-config-db.php' ) ) {
+	define( 'HM_ENV_ARCHITECTURE', 'chassis' );
+	require_once '/vagrant/local-config-db.php';
+	require_once '/vagrant/local-config-extensions.php';
+}


### PR DESCRIPTION
To make it so just installing this module doesn't cause fatals etc if the running environment isn't actually Chassis, we only require the files if they exists.

Also, define the HM_ENV_ARCHITECTURE which means `HM\Platform\get_environment_architecture()` will return `chassis`. That means that the `cloud` module will also be defaulted to `disabled`.