### PR TITLE
Add extensions to match our stacks

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -114,6 +114,15 @@ class Command extends BaseCommand {
 			'extensions' => [
 				'Chassis/phpdbg',
 				'shadyvb/chassis-redis',
+				'Chassis/Chassis-Elasticsearch',
+				'Chassis/v8js',
+				'Chassis/Tachyon',
+				'Chassis/intl',
+				'Chassis/composer',
+				'Chassis/nodejs',
+				'Chassis/mcrypt',
+				'Chassis/Chassis-Minio',
+				'Chassis/Cavalcade',
 			],
 		];
 		$yaml = Yaml::dump( $config );

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -121,7 +121,6 @@ class Command extends BaseCommand {
 				'Chassis/composer',
 				'Chassis/nodejs',
 				'Chassis/mcrypt',
-				'Chassis/Chassis-Minio',
 				'Chassis/Cavalcade',
 			],
 		];


### PR DESCRIPTION
- Chassis/Chassis-Elasticsearch
- Chassis/v8js
- Chassis/Tachyon
- Chassis/intl
- Chassis/composer
- Chassis/nodejs
- Chassis/mcrypt
- ~Chassis/Chassis-Minio~ not currently compatible with tachyon extension
- Chassis/Cavalcade